### PR TITLE
full_url support

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
@@ -2,6 +2,7 @@ package com.tikal.hudson.plugins.notification;
 
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
+import hudson.model.Hudson;
 import hudson.model.Job;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
@@ -107,11 +108,12 @@ public enum Protocol {
 		buildState.setUrl(run.getUrl());
 		buildState.setPhase(phase);
 		buildState.setStatus(status);
-		try {
-			buildState.setFullUrl(run.getAbsoluteUrl());
-		} catch (IllegalStateException ignored) {
-			// Ignored
+
+		String rootUrl = Hudson.getInstance().getRootUrl();
+		if (rootUrl != null) {
+			buildState.setFullUrl(rootUrl + run.getUrl());
 		}
+
 		jobState.setBuild(buildState);
 
 		ParametersAction paramsAction = run.getAction(ParametersAction.class);


### PR DESCRIPTION
Run#getAbsoluteUrl() is deprecated, and it seems to be not working properly.
so I replaced it with Hudson#getRootUrl() and Run#getUrl().
