### PR TITLE
Set the HTTP request property to appplication/json

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
@@ -71,9 +71,12 @@ public enum Protocol {
 		protected void send(String url, byte[] data) throws IOException {
             URL targetUrl = new URL(url);
             URLConnection connection = targetUrl.openConnection();
-            if (connection instanceof HttpURLConnection)
+            if (connection instanceof HttpURLConnection) {
+                ((HttpURLConnection) connection)
+                        .setRequestProperty("Content-Type", "application/json;charset=UTF-8");
                 ((HttpURLConnection) connection)
                         .setFixedLengthStreamingMode(data.length);
+            }
             connection.setDoInput(false);
             connection.setDoOutput(true);
             OutputStream output = connection.getOutputStream();


### PR DESCRIPTION
Set the HTTP request property to appplication/json to facilitate the proper handling of the notification JSON by the target server.
