### PR TITLE
Added HTTP connection timeouts

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
@@ -77,6 +77,8 @@ public enum Protocol {
 		}
 	},
 	HTTP {
+		private static final int HTTP_CONNECT_TIMEOUT_MS = 1000;
+		private static final int HTTP_READ_TIMEOUT_MS = 10000;
 		@Override
 		protected void send(String url, byte[] data) throws IOException {
             URL targetUrl = new URL(url);
@@ -89,6 +91,8 @@ public enum Protocol {
             connection.setFixedLengthStreamingMode(data.length);
             connection.setDoInput(true);
             connection.setDoOutput(true);
+            connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS);
+            connection.setReadTimeout(HTTP_READ_TIMEOUT_MS);
 
             connection.connect();
             try {


### PR DESCRIPTION
This change prevents an infinite wait in a connection object used in an HTTP notification.

We have observed Jenkins builds getting stuck in an uninterruptible state while trying to send a notification while following an HTTP redirect. 
