### PR TITLE
Selectable job lifecycle events, SCM information, Artifacts URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,77 +1,120 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns              = "http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi          = "http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.480</version>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.tikalk.hudson.plugins</groupId>
+    <artifactId>notification</artifactId>
+    <version>1.6-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <name>Jenkins Notification plugin</name>
+    <description>Sends notifications about jobs phases and status</description>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Notification+Plugin</url>
 
-	<groupId>com.tikalk.hudson.plugins</groupId>
-	<artifactId>notification</artifactId>
-	<version>1.6-SNAPSHOT</version>
-	<packaging>hpi</packaging>
-	<name>Jenkins Notification plugin</name>
-	<description>Sends notifications about jobs phases and status</description>
-	<url>https://wiki.jenkins-ci.org/display/JENKINS/Notification+Plugin</url>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.566</version>
+    </parent>
 
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
-  <dependencies>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>1.4</version>
-		</dependency>
-	</dependencies>
+    <build>
+        <pluginManagement>
+           <plugins>
+               <!-- http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.apache.maven.plugins%22%20AND%20a%3A%22maven-compiler-plugin%22 -->
+               <plugin>
+                   <groupId>org.apache.maven.plugins</groupId>
+                   <artifactId>maven-compiler-plugin</artifactId>
+                   <version>3.1</version>
+               </plugin>
+               <!-- http://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/ -->
+               <plugin>
+                   <groupId>org.jenkins-ci.tools</groupId>
+                   <artifactId>maven-hpi-plugin</artifactId>
+                   <version>1.109</version>
+               </plugin>
+           </plugins>
+       </pluginManagement>
+    </build>
 
-	<developers>
-		<developer>
-			<id>markb</id>
-			<name>Mark Berner</name>
-			<email>markb@tikalk.com</email>
-			<organization>Tikal Knowledge</organization>
-			<organizationUrl>http://tikalk.com</organizationUrl>
-		</developer>
-	</developers>
+    <dependencies>
+        <!-- http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.google.code.gson%22%20AND%20a%3A%22gson%22 -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2.4</version>
+        </dependency>
+        <!-- http://jcenter.bintray.com/org/jenkins-ci/plugins/s3/ -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>s3</artifactId>
+            <version>0.6</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
 
-	<scm>
-		<connection>scm:git:git://github.com/jenkinsci/notification-plugin.git</connection>
-		<developerConnection>scm:git:git@github.com:jenkinsci/notification-plugin.git</developerConnection>
-		<url>http://github.com/jenkinsci/notification-plugin</url>
-	</scm>
+    <developers>
+        <developer>
+            <id>markb</id>
+            <name>Mark Berner</name>
+            <email>markb@tikalk.com</email>
+            <organization>Tikal Knowledge</organization>
+            <organizationUrl>http://tikalk.com</organizationUrl>
+        </developer>
+        <developer>
+            <id>hagzag</id>
+            <name>Haggai Philip Zagury</name>
+            <email>hagzag@tikalk.com</email>
+            <organization>Tikal Knowledge</organization>
+            <organizationUrl>http://tikalk.com</organizationUrl>
+        </developer>
+        <developer>
+            <id>evgenyg</id>
+            <name>Evgeny Goldin</name>
+            <email>evgenyg@gmail.com</email>
+            <organization>AKQA</organization>
+            <organizationUrl>http://akqa.com</organizationUrl>
+        </developer>
+    </developers>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-			<comments>A business-friendly OSS license</comments>
-		</license>
-	</licenses>
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/notification-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/notification-plugin.git</developerConnection>
+        <url>http://github.com/jenkinsci/notification-plugin</url>
+    </scm>
 
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
 </project>
+

--- a/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
@@ -15,74 +15,88 @@
 package com.tikal.hudson.plugins.notification;
 
 import hudson.util.FormValidation;
-
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 public class Endpoint {
 
-	public static final Integer DEFAULT_TIMEOUT = 30000;
+    public static final Integer DEFAULT_TIMEOUT = 30000;
 
-	private Protocol protocol;
+    private Protocol protocol;
 
     /**
      * json as default
      */
-	private Format format = Format.JSON;
+    private Format format = Format.JSON;
 
-	private String url;
-	
-	private Integer timeout = DEFAULT_TIMEOUT;
+    private String url;
 
-	@DataBoundConstructor
-	public Endpoint(Protocol protocol, String url, Format format, Integer timeout) {
-		this.protocol = protocol;
-		this.url = url;
-		this.format = format;
-		this.setTimeout(timeout);
-	}
+    private String event = "all";
 
-	public int getTimeout() {
-		return timeout == null ? DEFAULT_TIMEOUT : timeout;
-	}
-	
-	public void setTimeout(Integer timeout) {
-		this.timeout =  timeout;		
-	}
+    private Integer timeout = DEFAULT_TIMEOUT;
 
-	public Protocol getProtocol() {
-		return protocol;
-	}
+    @DataBoundConstructor
+    public Endpoint(Protocol protocol, String url, String event, Format format, Integer timeout) {
+        setProtocol( protocol );
+        setUrl( url );
+        setEvent( event );
+        setFormat( format );
+        setTimeout( timeout );
+    }
 
-	public void setProtocol(Protocol protocol) {
-		this.protocol = protocol;
-	}
+    public int getTimeout() {
+        return timeout == null ? DEFAULT_TIMEOUT : timeout;
+    }
 
-	public String getUrl() {
-		return url;
-	}
+    public void setTimeout(Integer timeout) {
+        this.timeout =  timeout;
+    }
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
-	
-	public Format getFormat() {
+    public Protocol getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(Protocol protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getEvent (){
+        return event;
+    }
+
+    public void setEvent ( String event ){
+        this.event = event;
+    }
+
+    public Format getFormat() {
         if (this.format==null){
             this.format = Format.JSON;
         }
-		return format;
-	}
-	
-	public void setFormat(Format format) {
-		this.format = format;
-	}
+        return format;
+    }
 
-	public FormValidation doCheckURL(@QueryParameter(value = "url", fixEmpty = true) String url) {
-		if (url.equals("111"))
-			return FormValidation.ok();
-		else
-			return FormValidation.error("There's a problem here");
-	}
+    public void setFormat(Format format) {
+        this.format = format;
+    }
+
+    public FormValidation doCheckURL(@QueryParameter(value = "url", fixEmpty = true) String url) {
+        if (url.equals("111"))
+            return FormValidation.ok();
+        else
+            return FormValidation.error("There's a problem here");
+    }
+
+    public boolean isJson() {
+        return getFormat() == Format.JSON;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/tikal/hudson/plugins/notification/Format.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Format.java
@@ -13,32 +13,32 @@
  */
 package com.tikal.hudson.plugins.notification;
 
-import java.io.IOException;
-
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.thoughtworks.xstream.XStream;
 import com.tikal.hudson.plugins.notification.model.JobState;
 
-public enum Format {
-	XML {
-		private XStream xstream = new XStream();
+import java.io.IOException;
 
-		@Override
-		protected byte[] serialize(JobState jobState) throws IOException {
-			xstream.processAnnotations(JobState.class);
-			return xstream.toXML(jobState).getBytes();
-		}
-	},
-	JSON {
-		private Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
-		
-		@Override
-		protected byte[] serialize(JobState jobState) throws IOException {
-			return gson.toJson(jobState).getBytes();
-		}
-	};
-  
-  abstract protected byte[] serialize(JobState jobState) throws IOException;
+public enum Format {
+    XML {
+        private final XStream xstream = new XStream();
+
+        @Override
+        protected byte[] serialize(JobState jobState) throws IOException {
+            xstream.processAnnotations(JobState.class);
+            return xstream.toXML(jobState).getBytes( "UTF-8" );
+        }
+    },
+    JSON {
+        private final Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+
+        @Override
+        protected byte[] serialize(JobState jobState) throws IOException {
+            return gson.toJson(jobState).getBytes( "UTF-8" );
+        }
+    };
+
+    protected abstract byte[] serialize(JobState jobState) throws IOException;
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/HostnamePort.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HostnamePort.java
@@ -18,28 +18,28 @@ import java.util.regex.MatchResult;
 
 public class HostnamePort {
 
-	final public String hostname;
+    public final String hostname;
 
-	final public int port;
+    public final int port;
 
-	public HostnamePort(String hostname, int port) {
-		this.hostname = hostname;
-		this.port = port;
-	}
+    public HostnamePort(String hostname, int port) {
+        this.hostname = hostname;
+        this.port = port;
+    }
 
-	static public HostnamePort parseUrl(String url) {
-		try {
-			Scanner scanner = new Scanner(url);
-			scanner.findInLine("(.+):(\\d{1,5})");
-			MatchResult result = scanner.match();
-			if (result.groupCount() != 2) {
-				return null;
-			}
-			String hostname = result.group(1);
-			int port = Integer.valueOf(result.group(2));
-			return new HostnamePort(hostname, port);
-		} catch (Exception e) {
-			return null;
-		}
-	}
+    public static HostnamePort parseUrl(String url) {
+        try {
+            Scanner scanner = new Scanner(url);
+            scanner.findInLine("(.+):(\\d{1,5})");
+            MatchResult result = scanner.match();
+            if (result.groupCount() != 2) {
+                return null;
+            }
+            String hostname = result.group(1);
+            int port = Integer.valueOf(result.group(2));
+            return new HostnamePort(hostname, port);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationProperty.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationProperty.java
@@ -13,28 +13,30 @@
  */
 package com.tikal.hudson.plugins.notification;
 
-import hudson.model.JobProperty;
 import hudson.model.AbstractProject;
-
-import java.util.List;
-
+import hudson.model.JobProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class HudsonNotificationProperty extends
-		JobProperty<AbstractProject<?, ?>> {
+        JobProperty<AbstractProject<?, ?>> {
 
-	final public List<Endpoint> endpoints;
+    public final List<Endpoint> endpoints;
 
-	@DataBoundConstructor
-	public HudsonNotificationProperty(List<Endpoint> endpoints) {
-		this.endpoints = endpoints;
-	}
+    @DataBoundConstructor
+    public HudsonNotificationProperty(List<Endpoint> endpoints) {
+        this.endpoints = new ArrayList<Endpoint>( endpoints );
+    }
 
-	public List<Endpoint> getEndpoints() {
-		return endpoints;
-	}
+    public List<Endpoint> getEndpoints() {
+        return endpoints;
+    }
 
-	public HudsonNotificationPropertyDescriptor getDescriptor() {
-		return (HudsonNotificationPropertyDescriptor) super.getDescriptor();
-	}
+    @SuppressWarnings( "CastToConcreteClass" )
+    @Override
+    public HudsonNotificationPropertyDescriptor getDescriptor() {
+        return (HudsonNotificationPropertyDescriptor) super.getDescriptor();
+    }
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
@@ -14,85 +14,88 @@
 package com.tikal.hudson.plugins.notification;
 
 import hudson.Extension;
-import hudson.model.JobPropertyDescriptor;
 import hudson.model.Job;
+import hudson.model.JobPropertyDescriptor;
 import hudson.util.FormValidation;
+import net.sf.json.JSON;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.json.JSON;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-
 @Extension
 public final class HudsonNotificationPropertyDescriptor extends JobPropertyDescriptor {
 
-	public HudsonNotificationPropertyDescriptor() {
-		super(HudsonNotificationProperty.class);
-		load();
-	}
+    public HudsonNotificationPropertyDescriptor() {
+        super(HudsonNotificationProperty.class);
+        load();
+    }
 
-	private List<Endpoint> endpoints = new ArrayList<Endpoint>();
+    private List<Endpoint> endpoints = new ArrayList<Endpoint>();
 
-	public boolean isEnabled() {
-		return !endpoints.isEmpty();
-	}
+    public boolean isEnabled() {
+        return !endpoints.isEmpty();
+    }
 
-	public List<Endpoint> getTargets() {
-		return endpoints;
-	}
+    public List<Endpoint> getTargets() {
+        return endpoints;
+    }
 
-	public void setEndpoints(List<Endpoint> endpoints) {
-		this.endpoints = endpoints;
-	}
+    public void setEndpoints(List<Endpoint> endpoints) {
+        this.endpoints = new ArrayList<Endpoint>( endpoints );
+    }
 
-	@Override
-	public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends Job> jobType) {
-		return true;
-	}
+    @Override
+    public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends Job> jobType) {
+        return true;
+    }
 
-	public String getDisplayName() {
-		return "Hudson Job Notification";
-	}
+    @Override
+    public String getDisplayName() {
+        return "Hudson Job Notification";
+    }
 
-	@Override
-	public HudsonNotificationProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+    public int getDefaultTimeout(){
+        return Endpoint.DEFAULT_TIMEOUT;
+    }
 
-		List<Endpoint> endpoints = new ArrayList<Endpoint>();
-		if (formData != null && !formData.isNullObject()) {
-			JSON endpointsData = (JSON) formData.get("endpoints");
-			if (endpointsData != null && !endpointsData.isEmpty()) {
-				if (endpointsData.isArray()) {
-					JSONArray endpointsArrayData = (JSONArray) endpointsData;
-					endpoints.addAll(req.bindJSONToList(Endpoint.class, endpointsArrayData));
-				} else {
-					JSONObject endpointsObjectData = (JSONObject) endpointsData;
-					endpoints.add(req.bindJSON(Endpoint.class, endpointsObjectData));
-				}
-			}
-		}
-		HudsonNotificationProperty notificationProperty = new HudsonNotificationProperty(endpoints);
-		return notificationProperty;
-	}
+    @Override
+    public HudsonNotificationProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
 
-	public FormValidation doCheckUrl(@QueryParameter(value = "url", fixEmpty = true) String url, @QueryParameter(value = "protocol") String protocolParameter) {
-		Protocol protocol = Protocol.valueOf(protocolParameter);
-		try {
-			protocol.validateUrl(url);
-			return FormValidation.ok();
-		} catch (Exception e) {
-			return FormValidation.error(e.getMessage());
-		}
-	}
+        List<Endpoint> endpoints = new ArrayList<Endpoint>();
+        if (formData != null && !formData.isNullObject()) {
+            JSON endpointsData = (JSON) formData.get("endpoints");
+            if (endpointsData != null && !endpointsData.isEmpty()) {
+                if (endpointsData.isArray()) {
+                    JSONArray endpointsArrayData = (JSONArray) endpointsData;
+                    endpoints.addAll(req.bindJSONToList(Endpoint.class, endpointsArrayData));
+                } else {
+                    JSONObject endpointsObjectData = (JSONObject) endpointsData;
+                    endpoints.add(req.bindJSON(Endpoint.class, endpointsObjectData));
+                }
+            }
+        }
+        HudsonNotificationProperty notificationProperty = new HudsonNotificationProperty(endpoints);
+        return notificationProperty;
+    }
 
-	@Override
-	public boolean configure(StaplerRequest req, JSONObject formData) {
-		save();
-		return true;
-	}
+    public FormValidation doCheckUrl(@QueryParameter(value = "url", fixEmpty = true) String url, @QueryParameter(value = "protocol") String protocolParameter) {
+        Protocol protocol = Protocol.valueOf(protocolParameter);
+        try {
+            protocol.validateUrl(url);
+            return FormValidation.ok();
+        } catch (Exception e) {
+            return FormValidation.error(e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject formData) {
+        save();
+        return true;
+    }
 
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/JobListener.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/JobListener.java
@@ -22,23 +22,23 @@ import hudson.model.listeners.RunListener;
 @SuppressWarnings("rawtypes")
 public class JobListener extends RunListener<Run> {
 
-	public JobListener() {
-		super(Run.class);
-	}
+    public JobListener() {
+        super(Run.class);
+    }
 
-	@Override
-	public void onStarted(Run r, TaskListener listener) {
-		Phase.STARTED.handle(r, listener);
-	}
+    @Override
+    public void onStarted(Run r, TaskListener listener) {
+        Phase.STARTED.handle(r, listener);
+    }
 
-	@Override
-	public void onCompleted(Run r, TaskListener listener) {
-		Phase.COMPLETED.handle(r, listener);
-	}
+    @Override
+    public void onCompleted(Run r, TaskListener listener) {
+        Phase.COMPLETED.handle(r, listener);
+    }
 
-	@Override
-	public void onFinalized(Run r) {
-		Phase.FINISHED.handle(r, TaskListener.NULL);
-	}
+    @Override
+    public void onFinalized(Run r) {
+        Phase.FINALIZED.handle(r, TaskListener.NULL);
+    }
 
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -14,78 +14,163 @@
 package com.tikal.hudson.plugins.notification.model;
 
 import com.tikal.hudson.plugins.notification.Phase;
+import hudson.model.AbstractBuild;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.plugins.s3.Entry;
+import hudson.plugins.s3.S3BucketPublisher;
+import hudson.util.DescribableList;
+import jenkins.model.Jenkins;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class BuildState {
 
-	private String fullUrl;
+    private String fullUrl;
 
-	private int number;
+    private int number;
 
-	private Phase phase;
+    private Phase phase;
 
-	private String status;
+    private String status;
 
-	private String url;
+    private String url;
 
-	private String displayName;
+    private String displayName;
 
-	private Map<String, String> parameters;
+    private ScmState scm;
 
-	public int getNumber() {
-		return number;
-	}
+    private Map<String, String> parameters;
 
-	public void setNumber(int number) {
-		this.number = number;
-	}
+    private Map<String, List<String>> artifacts;
 
-	public Phase getPhase() {
-		return phase;
-	}
+    public int getNumber() {
+        return number;
+    }
 
-	public void setPhase(Phase phase) {
-		this.phase = phase;
-	}
+    public void setNumber(int number) {
+        this.number = number;
+    }
 
-	public String getStatus() {
-		return status;
-	}
+    public Phase getPhase() {
+        return phase;
+    }
 
-	public void setStatus(String status) {
-		this.status = status;
-	}
+    public void setPhase(Phase phase) {
+        this.phase = phase;
+    }
 
-	public String getUrl() {
-		return url;
-	}
+    public String getStatus() {
+        return status;
+    }
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	public String getFullUrl() {
-		return fullUrl;
-	}
+    public String getUrl() {
+        return url;
+    }
 
-	public void setFullUrl(String fullUrl) {
-		this.fullUrl = fullUrl;
-	}
+    public void setUrl(String url) {
+        this.url = url;
+    }
 
-	public Map<String, String> getParameters() {
-		return parameters;
-	}
+    public String getFullUrl() {
+        return fullUrl;
+    }
 
-	public void setParameters(Map<String, String> params) {
-		this.parameters = params;
-	}
+    public void setFullUrl(String fullUrl) {
+        this.fullUrl = fullUrl;
+    }
 
-	public void setDisplayName(String displayName) {
-		this.displayName = displayName;
-	}
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
 
-	public String getDisplayName() {
-		return displayName;
-	}
+    public void setParameters(Map<String, String> params) {
+        this.parameters = new HashMap<String, String>( params );
+    }
+
+    public Map<String, List<String>> getArtifacts () {
+        return artifacts;
+    }
+
+    public void setArtifacts ( Map<String, List<String>> artifacts )
+    {
+        this.artifacts = new HashMap<String, List<String>>( artifacts );
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public ScmState getScm ()
+    {
+        return scm;
+    }
+
+    public void setScm ( ScmState scmState )
+    {
+        this.scm = scmState;
+    }
+
+
+    /**
+     * Updates artifacts Map with S3 links, if corresponding publisher is available.
+     */
+    public void updateArtifacts ( Job job, Run run )
+    {
+        if ( ! ( run instanceof AbstractBuild )){ return; }
+        if ( Jenkins.getInstance().getPlugin( "s3" ) == null ) { return; }
+
+        DescribableList   publishers  = (( AbstractBuild ) run ).getProject().getPublishersList();
+        S3BucketPublisher s3Publisher = ( S3BucketPublisher ) publishers.get( S3BucketPublisher.class );
+
+        if ( s3Publisher == null ){ return; }
+
+        for ( Entry entry : s3Publisher.getEntries()) {
+
+            if ( isEmpty( entry.sourceFile, entry.selectedRegion, entry.bucket )){ continue; }
+            String fileName = new File( entry.sourceFile ).getName();
+            if ( isEmpty( fileName )){ continue; }
+
+            // https://s3-eu-west-1.amazonaws.com/evgenyg-temp/
+            String bucketUrl = String.format( "https://s3-%s.amazonaws.com/%s",
+                                              entry.selectedRegion.toLowerCase().replace( '_', '-' ),
+                                              entry.bucket );
+
+            String fileUrl   = entry.managedArtifacts ?
+                // https://s3-eu-west-1.amazonaws.com/evgenyg-temp/jobs/notification-plugin/21/notification.hpi
+                String.format( "%s/jobs/%s/%s/%s", bucketUrl, job.getName(), run.getNumber(), fileName ) :
+                // https://s3-eu-west-1.amazonaws.com/evgenyg-temp/notification.hpi
+                String.format( "%s/%s", bucketUrl, fileName );
+
+            if ( artifacts.get( fileName ) == null ) {
+                artifacts.put( fileName, Arrays.asList( fileUrl ));
+            }
+            else {
+                artifacts.get( fileName ).add( fileUrl );
+            }
+        }
+    }
+
+    private static boolean isEmpty( String ... strings ) {
+
+        for ( String s : strings ) {
+            if (( s == null ) || ( s.trim().length() < 1 )){
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/JobState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/JobState.java
@@ -18,33 +18,33 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("job")
 public class JobState {
 
-	private String name;
+    private String name;
 
-	private String url;
+    private String url;
 
-	private BuildState build;
+    private BuildState build;
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public String getUrl() {
-		return url;
-	}
+    public String getUrl() {
+        return url;
+    }
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
+    public void setUrl(String url) {
+        this.url = url;
+    }
 
-	public BuildState getBuild() {
-		return build;
-	}
+    public BuildState getBuild() {
+        return build;
+    }
 
-	public void setBuild(BuildState build) {
-		this.build = build;
-	}
+    public void setBuild(BuildState build) {
+        this.build = build;
+    }
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/ScmState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/ScmState.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tikal.hudson.plugins.notification.model;
+
+
+public class ScmState
+{
+    private String url;
+
+    private String branch;
+
+    private String commit;
+
+    public String getUrl ()
+    {
+        return url;
+    }
+
+    public void setUrl ( String url )
+    {
+        this.url = url;
+    }
+
+    public String getBranch ()
+    {
+        return branch;
+    }
+
+    public void setBranch ( String branch )
+    {
+        this.branch = branch;
+    }
+
+    public String getCommit ()
+    {
+        return commit;
+    }
+
+    public void setCommit ( String commit )
+    {
+        this.commit = commit;
+    }
+}

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
@@ -1,55 +1,66 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-	<f:section title="Job Notifications">
-		<f:entry title="Notification Endpoints" field="endpoints">
-			<f:repeatable name="endpoints" var="endpoint"
-				items="${instance.endpoints}" add="${%Add Endpoint}">
-				<table class="center-align">
-					<f:entry field="endpoint">
-						<table>
-							<tr>
-								<td>
-									<f:entry title="Format" description="" field="format">
-										<select class="setting-input" name="format">
-											<f:option value="JSON" selected="${endpoint.format=='JSON'}">JSON</f:option>
-											<f:option value="XML" selected="${endpoint.format=='XML'}">XML</f:option>
-										</select>
-									</f:entry>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<f:entry title="Protocol" description="" field="protocol">
-										<select class="setting-input" name="protocol">
-											<f:option value="UDP" selected="${endpoint.protocol=='UDP'}">UDP</f:option>
-											<f:option value="TCP" selected="${endpoint.protocol=='TCP'}">TCP</f:option>
-											<f:option value="HTTP" selected="${endpoint.protocol=='HTTP'}">HTTP</f:option>
-										</select>
-									</f:entry>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<f:entry title="URL" description="Where to send messages"
-										field="url">
-										<f:textbox name="url" value="${endpoint.url}" />
-									</f:entry>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<f:entry title="Timeout" description="Timeout (in ms)"
-										field="timeout">
-										<f:textbox name="timeout" value="${endpoint.timeout}" />
-									</f:entry>
-								</td>
-							</tr>
-						</table>
-					</f:entry>
-					<f:repeatableDeleteButton value="${%Delete}" />
-				</table>
-			</f:repeatable>
-		</f:entry>
-	</f:section>
+    <f:section title="Job Notifications">
+        <f:entry title="Notification Endpoints" field="endpoints">
+            <f:repeatable name="endpoints" var="endpoint"
+                items="${instance.endpoints}" add="${%Add Endpoint}">
+                <table class="center-align">
+                    <f:entry field="endpoint">
+                        <table>
+                            <tr>
+                                <td>
+                                    <f:entry title="Format" description="" field="format">
+                                        <select class="setting-input" name="format">
+                                            <f:option value="JSON" selected="${endpoint.format=='JSON'}">JSON</f:option>
+                                            <f:option value="XML" selected="${endpoint.format=='XML'}">XML</f:option>
+                                        </select>
+                                    </f:entry>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <f:entry title="Protocol" description="" field="protocol">
+                                        <select class="setting-input" name="protocol">
+                                            <f:option value="HTTP" selected="${endpoint.protocol=='HTTP'}">HTTP</f:option>
+                                            <f:option value="TCP" selected="${endpoint.protocol=='TCP'}">TCP</f:option>
+                                            <f:option value="UDP" selected="${endpoint.protocol=='UDP'}">UDP</f:option>
+                                        </select>
+                                    </f:entry>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <f:entry title="Event" description="Job lifecycle event triggering notification" field="event">
+                                        <select class="setting-input" name="event">
+                                            <f:option value="all"       selected="${endpoint.event == 'all'}">All Events</f:option>
+                                            <f:option value="started"   selected="${endpoint.event == 'started'}">Job Started</f:option>
+                                            <f:option value="completed" selected="${endpoint.event == 'completed'}">Job Completed</f:option>
+                                            <f:option value="finalized" selected="${endpoint.event == 'finalized'}">Job Finalized</f:option>
+                                        </select>
+                                    </f:entry>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <f:entry title="URL" description="Where to send messages" field="url">
+                                        <f:textbox name="url" value="${endpoint.url}" />
+                                    </f:entry>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <f:entry title="Timeout" description="Timeout (in ms)"
+                                        field="timeout">
+                                        <f:textbox name="timeout" value="${endpoint.timeout}" default="${descriptor.defaultTimeout}"/>
+                                    </f:entry>
+                                </td>
+                            </tr>
+                        </table>
+                    </f:entry>
+                    <f:repeatableDeleteButton value="${%Delete}" />
+                </table>
+            </f:repeatable>
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-url.html
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-url.html
@@ -1,8 +1,8 @@
 <div align="left">
 <ul>
-	<li>URL format for UDP and TCP protocols is
-	(hostname|IpAddress):portNumber, e.g. 10.10.10.10:12345</li>
-	<li>URL format for HTTP protocol is any legal http address, e.g.
-	http://[user:password@]myhost.com:8080/monitor</li>
+    <li>URL format for UDP and TCP protocols is
+    (hostname|IpAddress):portNumber, e.g. 10.10.10.10:12345</li>
+    <li>URL format for HTTP protocol is any legal http address, e.g.
+    http://[user:password@]myhost.com:8080/monitor</li>
 </ul>
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,5 +1,5 @@
 <div>
-	This plugin from
-	<a href="http://www.tikalk.com">Tikal Knowledge</a>
-	allows sending running Jobs status notifications.
+    This plugin from
+    <a href="http://www.tikalk.com">Tikal Knowledge</a>
+    allows sending running Jobs status notifications.
 </div>

--- a/src/main/webapp/help-globalConfig.html
+++ b/src/main/webapp/help-globalConfig.html
@@ -3,12 +3,12 @@
 Knowledge</a> allows sending Job Status notifications.</p>
 <pre>
 {
-	"name":"JobName", 
-	"url":"JobUrl", 
-	"build":{
-		"number":1,
-		"phase":"STARTED", 
-		"status":"FAILED"
-	}
+    "name":"JobName",
+    "url":"JobUrl",
+    "build":{
+        "number":1,
+        "phase":"STARTED",
+        "status":"FAILED"
+    }
 }
 </pre></div>

--- a/src/main/webapp/help-projectConfig.html
+++ b/src/main/webapp/help-projectConfig.html
@@ -3,12 +3,12 @@
 Knowledge</a> allows sending Job Status notifications.</p>
 <pre>
 {
-	"name":"JobName", 
-	"url":"JobUrl", 
-	"build":{
-		"number":1,
-		"phase":"STARTED", 
-		"status":"FAILED"
-	}
+    "name":"JobName",
+    "url":"JobUrl",
+    "build":{
+        "number":1,
+        "phase":"STARTED",
+        "status":"FAILED"
+    }
 }
 </pre></div>

--- a/src/test/java/com/tikal/hudson/plugins/notification/ProtocolTest.java
+++ b/src/test/java/com/tikal/hudson/plugins/notification/ProtocolTest.java
@@ -23,13 +23,14 @@
  */
 package com.tikal.hudson.plugins.notification;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import com.google.common.base.Objects;
+import com.google.common.io.CharStreams;
+import junit.framework.TestCase;
+import org.mortbay.jetty.HttpHeaders;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.bio.SocketConnector;
+import org.mortbay.jetty.servlet.ServletHandler;
+import org.mortbay.jetty.servlet.ServletHolder;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -37,17 +38,13 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.bind.DatatypeConverter;
-
-import com.google.common.base.Objects;
-import com.google.common.io.CharStreams;
-
-import org.mortbay.jetty.HttpHeaders;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
-
-import junit.framework.TestCase;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -65,7 +62,7 @@ public class ProtocolTest extends TestCase {
       this.method = request.getMethod();
       this.body = CharStreams.toString(request.getReader());
       String auth = request.getHeader("Authorization");
-      this.userInfo = (null == auth) 
+      this.userInfo = (null == auth)
               ? null
               : new String(DatatypeConverter.parseBase64Binary(auth.split(" ")[1])) + "@";
     }
@@ -219,7 +216,7 @@ public class ProtocolTest extends TestCase {
     assertTrue(requests.isEmpty());
 
     String uri = urlFactory.getUrl("/realpath");
-    Protocol.HTTP.send(uri, "Hello".getBytes(),30000);
+    Protocol.HTTP.send(uri, "Hello".getBytes(),30000, true);
 
     assertEquals(new Request(uri, "POST", "Hello"), requests.take());
     assertTrue(requests.isEmpty());
@@ -233,7 +230,7 @@ public class ProtocolTest extends TestCase {
     assertTrue(requests.isEmpty());
 
     String uri = urlFactory.getUrl("/realpath");
-    Protocol.HTTP.send(uri, "Hello".getBytes(),30000);
+    Protocol.HTTP.send(uri, "Hello".getBytes(),30000, true);
 
     Request theRequest = requests.take();
     assertTrue(requests.isEmpty());
@@ -251,7 +248,7 @@ public class ProtocolTest extends TestCase {
     assertTrue(requests.isEmpty());
 
     String uri = redirectorUrlFactory.getUrl("/path");
-    Protocol.HTTP.send(uri, "RedirectMe".getBytes(),30000);
+    Protocol.HTTP.send(uri, "RedirectMe".getBytes(),30000, true);
 
     assertEquals(new Request(uri, "POST", "RedirectMe"), requests.take());
     assertEquals(new Request(redirectUri, "POST", "RedirectMe"), requests.take());

--- a/src/test/java/com/tikal/hudson/plugins/notification/test/HostnamePortTest.java
+++ b/src/test/java/com/tikal/hudson/plugins/notification/test/HostnamePortTest.java
@@ -20,17 +20,17 @@ import org.junit.Test;
 import com.tikal.hudson.plugins.notification.HostnamePort;
 
 public class HostnamePortTest {
-	
-	@Test
-	public void parseUrlTest() {
-		HostnamePort hnp = HostnamePort.parseUrl("111");
-		Assert.assertNull(hnp);
-		hnp = HostnamePort.parseUrl(null);
-		Assert.assertNull(hnp);
-		hnp = HostnamePort.parseUrl("localhost:123");
-		Assert.assertEquals("localhost", hnp.hostname);
-		Assert.assertEquals(123, hnp.port);
-		hnp = HostnamePort.parseUrl("localhost:123456");
-		Assert.assertEquals(12345, hnp.port);
-	}
+
+    @Test
+    public void parseUrlTest() {
+        HostnamePort hnp = HostnamePort.parseUrl("111");
+        Assert.assertNull(hnp);
+        hnp = HostnamePort.parseUrl(null);
+        Assert.assertNull(hnp);
+        hnp = HostnamePort.parseUrl("localhost:123");
+        Assert.assertEquals("localhost", hnp.hostname);
+        Assert.assertEquals(123, hnp.port);
+        hnp = HostnamePort.parseUrl("localhost:123456");
+        Assert.assertEquals(12345, hnp.port);
+    }
 }


### PR DESCRIPTION
New features:
- It is now possible to select job lifecycle event to trigger notification - job started, completed, finalized or all of them (the default behavior).
- Scm information is reported - url, branch, commit. Only Git is supported so far.
- Artifacts information is reported - Jenkins (if archived) and S3 (if uploaded to S3) URLs.
  Improvements:
- When defining an endpoint - default endpoint timeout (30000) is pre-filled in a form.
- When defining an endpoint - protocols order in  a dropdown is changed to HTTP, TCP, UDP.
- Endpoint URL validation error now includes the faulty URL if it's not empty.
- Correct "Content-Type" header is sent, according to XML or JSON payload submitted.
- POM dependencies updated.
- Various IDEA warning were eliminated, like proper sorting of access modifiers.
- Tabs are replaced by 4 spaces.
