### PR TITLE
Proposed fix for JENKINS-27323 IndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -127,7 +127,7 @@ public enum Phase {
         StringBuilder log = new StringBuilder("");
         Integer loglines = target.getLoglines();
 
-        if (null == loglines) {
+        if (null == loglines || 0 == loglines) {
                 return log;
         }
 


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-27323 which happens if you leave the log lines as 0 (to emulate pre-1.9 behaviour). Although there is a fix coming in Jenkins core 1.613 (https://issues.jenkins-ci.org/browse/JENKINS-27441), this very minor change should allow the plugin to work on existing versions of Jenkins
