### PR TITLE
Added attribute queueId to BuildState.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.566</version>
+        <version>1.605</version>
     </parent>
 
     <repositories>

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -83,6 +83,7 @@ public enum Phase {
         jobState.setBuild( buildState );
 
         buildState.setNumber( run.number );
+        buildState.setQueueId( run.getQueueId() );
         buildState.setUrl( run.getUrl());
         buildState.setPhase( this );
         buildState.setScm( scmState );

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -35,6 +35,8 @@ public class BuildState {
 
     private int number;
 
+    private long queueId;
+
     private Phase phase;
 
     private String status;
@@ -67,6 +69,14 @@ public class BuildState {
 
     public void setNumber(int number) {
         this.number = number;
+    }
+
+    public long getQueueId() {
+        return queueId;
+    }
+
+    public void setQueueId(long queue) {
+        this.queueId = queue;
     }
 
     public Phase getPhase() {


### PR DESCRIPTION
The queueId attribute has been added to the BuildState. The Jenkins SDK version was upped because in 1.566 the Hudson model did not expose the queueId.