### PR TITLE
FIXED JENKINS-26162 duplicate filename bug

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -158,7 +158,7 @@ public class BuildState {
 
         for ( Run.Artifact a : buildArtifacts ) {
             String artifactUrl = Jenkins.getInstance().getRootUrl() + run.getUrl() + "artifact/" + a.getHref();
-            updateArtifact( a.getFileName(), "archive", artifactUrl );
+            updateArtifact( a.relativePath, "archive", artifactUrl );
         }
     }
 


### PR DESCRIPTION
Not sure if this is the best way to solve this, but it keeps the keys unique and is working for us.