### PR TITLE
Add retries, pipeline job support and secret URLS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,16 @@
             <version>1.0.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1.21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
@@ -15,6 +15,7 @@
 package com.tikal.hudson.plugins.notification;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public class Endpoint {
 
@@ -43,17 +44,34 @@ public class Endpoint {
     
     private Integer retries = DEFAULT_RETRIES;
 
-    @DataBoundConstructor
-    public Endpoint(Protocol protocol, UrlInfo urlInfo, String event, Format format, Integer timeout, Integer loglines, Integer retries) {
+    /**
+     * Adds a new endpoint for notifications
+     * @param protocol - Protocol to use
+     * @param url Public URL
+     * @param event - Event to fire on.
+     * @param format - Format to send message in.
+     * @param timeout Timeout for sending data
+     * @param loglines - Number of lines to send
+     */
+    @Deprecated
+    public Endpoint(Protocol protocol, String url, String event, Format format, Integer timeout, Integer loglines) {
         setProtocol( protocol );
+        setUrlInfo( new UrlInfo(UrlType.PUBLIC, url) );
         setEvent( event );
         setFormat( format );
         setTimeout( timeout );
-        setUrlInfo ( urlInfo );
         setLoglines( loglines );
-        setRetries( retries );
     }
-
+    
+    /**
+     * Adds a new endpoint for notifications
+     * @param urlInfo Information about the target URL for the event.
+     */
+    @DataBoundConstructor
+    public Endpoint(UrlInfo urlInfo) {
+        setUrlInfo ( urlInfo );
+    }
+    
     public UrlInfo getUrlInfo() {
         if (this.urlInfo == null) {
             this.urlInfo = new UrlInfo(UrlType.PUBLIC, "");
@@ -69,6 +87,11 @@ public class Endpoint {
         return timeout == null ? DEFAULT_TIMEOUT : timeout;
     }
 
+    /**
+     * Sets a timeout for the notification.
+     * @param timeout - Timeout in ms.  Default is 30s (30000)
+     */
+    @DataBoundSetter
     public void setTimeout(Integer timeout) {
         this.timeout =  timeout;
     }
@@ -77,6 +100,12 @@ public class Endpoint {
         return protocol;
     }
 
+    /**
+     * Sets the protocol for the 
+     * @param protocol Protocol to use.  Valid values are: UDP, TCP, HTTP.  Default is HTTP.
+     * HTTP event target urls must start with 'http'
+     */
+    @DataBoundSetter
     public void setProtocol(Protocol protocol) {
         this.protocol = protocol;
     }
@@ -85,6 +114,11 @@ public class Endpoint {
         return event;
     }
 
+    /**
+     * Sets the specific event to contact the endpoint for.
+     * @param event 'STARTED' - Fire on job started. 'COMPLETED' - Fire on job completed. 'FINALIZED' - Fire on job finalized.
+     */
+    @DataBoundSetter
     public void setEvent ( String event ){
         this.event = event;
     }
@@ -96,6 +130,11 @@ public class Endpoint {
         return format;
     }
 
+    /**
+     * Format of the message sent to the endpoint should
+     * @param format 'XML' or 'JSON'
+     */
+    @DataBoundSetter
     public void setFormat(Format format) {
         this.format = format;
     }
@@ -104,6 +143,11 @@ public class Endpoint {
         return this.loglines;
     }
 
+    /**
+     * Set the number of log lines to send with the message.
+     * @param loglines - Default 0, -1 for unlimited.
+     */
+    @DataBoundSetter
     public void setLoglines(Integer loglines) {
         this.loglines = loglines;
     }
@@ -116,6 +160,11 @@ public class Endpoint {
         return this.retries == null ? DEFAULT_RETRIES : this.retries;
     }
     
+    /**
+     * Number of retries before giving up on contacting an endpoint
+     * @param retries - Number of retries.  Default 0.
+     */
+    @DataBoundSetter
     public void setRetries(Integer retries) {
         this.retries = retries;
     }

--- a/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
@@ -23,7 +23,7 @@ public class Endpoint {
     
     public static final Integer DEFAULT_RETRIES = 0;
 
-    private Protocol protocol;
+    private Protocol protocol = Protocol.HTTP;
     
     /**
      * json as default

--- a/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationProperty.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationProperty.java
@@ -13,7 +13,7 @@
  */
 package com.tikal.hudson.plugins.notification;
 
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.JobProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class HudsonNotificationProperty extends
-        JobProperty<AbstractProject<?, ?>> {
+        JobProperty<Job<?, ?>> {
 
     public final List<Endpoint> endpoints;
 

--- a/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
@@ -76,6 +76,10 @@ public final class HudsonNotificationPropertyDescriptor extends JobPropertyDescr
         return Endpoint.DEFAULT_TIMEOUT;
     }
     
+    public int getDefaultRetries(){
+        return Endpoint.DEFAULT_RETRIES;
+    }
+
     @Override
     public HudsonNotificationProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
         List<Endpoint> endpoints = new ArrayList<Endpoint>();

--- a/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
@@ -114,15 +114,13 @@ public final class HudsonNotificationPropertyDescriptor extends JobPropertyDescr
         else {
             throw new FormException("Expected either a public url or secret url id", "urlInfo");
         }
-        Endpoint endpoint = new Endpoint(
-            Protocol.valueOf(endpointObjectData.getString("protocol")),
-            urlInfo,
-            endpointObjectData.getString("event"),
-            Format.valueOf(endpointObjectData.getString("format")),
-            endpointObjectData.getInt("timeout"),
-            endpointObjectData.getInt("loglines"),
-            endpointObjectData.getInt("retries")
-        );
+        Endpoint endpoint = new Endpoint(urlInfo);
+        endpoint.setEvent(endpointObjectData.getString("event"));
+        endpoint.setFormat(Format.valueOf(endpointObjectData.getString("format")));
+        endpoint.setProtocol(Protocol.valueOf(endpointObjectData.getString("protocol")));
+        endpoint.setTimeout(endpointObjectData.getInt("timeout"));
+        endpoint.setRetries(endpointObjectData.getInt("retries"));
+        endpoint.setLoglines(endpointObjectData.getInt("loglines"));
         return endpoint;
     }
     

--- a/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
@@ -13,10 +13,20 @@
  */
 package com.tikal.hudson.plugins.notification;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import hudson.Extension;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.JobPropertyDescriptor;
+import hudson.RelativePath;
+import hudson.security.ACL;
+import hudson.security.Permission;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -24,7 +34,11 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
 
 @Extension
 public final class HudsonNotificationPropertyDescriptor extends JobPropertyDescriptor {
@@ -61,35 +75,113 @@ public final class HudsonNotificationPropertyDescriptor extends JobPropertyDescr
     public int getDefaultTimeout(){
         return Endpoint.DEFAULT_TIMEOUT;
     }
-
+    
     @Override
     public HudsonNotificationProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-
         List<Endpoint> endpoints = new ArrayList<Endpoint>();
         if (formData != null && !formData.isNullObject()) {
             JSON endpointsData = (JSON) formData.get("endpoints");
             if (endpointsData != null && !endpointsData.isEmpty()) {
                 if (endpointsData.isArray()) {
                     JSONArray endpointsArrayData = (JSONArray) endpointsData;
-                    endpoints.addAll(req.bindJSONToList(Endpoint.class, endpointsArrayData));
+                    for (int i = 0; i < endpointsArrayData.size(); i++) {
+                        JSONObject endpointsObject = endpointsArrayData.getJSONObject(i);
+                        endpoints.add(convertJson((JSONObject) endpointsObject));
+                    }
                 } else {
-                    JSONObject endpointsObjectData = (JSONObject) endpointsData;
-                    endpoints.add(req.bindJSON(Endpoint.class, endpointsObjectData));
+                    endpoints.add(convertJson((JSONObject) endpointsData));
                 }
             }
         }
         HudsonNotificationProperty notificationProperty = new HudsonNotificationProperty(endpoints);
         return notificationProperty;
     }
-
-    public FormValidation doCheckUrl(@QueryParameter(value = "url", fixEmpty = true) String url, @QueryParameter(value = "protocol") String protocolParameter) {
+    
+    private Endpoint convertJson(JSONObject endpointObjectData) throws FormException {
+        // Transform the data to get the public/secret URL data
+        JSONObject urlInfoData = endpointObjectData.getJSONObject("urlInfo");
+        UrlInfo urlInfo = null;
+        if (urlInfoData.containsKey("publicUrl")) {
+            urlInfo = new UrlInfo(UrlType.PUBLIC, urlInfoData.getString("publicUrl"));
+        }
+        else if (urlInfoData.containsKey("secretUrl")) {
+            urlInfo = new UrlInfo(UrlType.SECRET, urlInfoData.getString("secretUrl"));
+        }
+        else {
+            throw new FormException("Expected either a public url or secret url id", "urlInfo");
+        }
+        Endpoint endpoint = new Endpoint(
+            Protocol.valueOf(endpointObjectData.getString("protocol")),
+            urlInfo,
+            endpointObjectData.getString("event"),
+            Format.valueOf(endpointObjectData.getString("format")),
+            endpointObjectData.getInt("timeout"),
+            endpointObjectData.getInt("loglines"),
+            endpointObjectData.getInt("retries")
+        );
+        return endpoint;
+    }
+    
+    public FormValidation doCheckPublicUrl(
+            @QueryParameter(value = "publicUrl", fixEmpty = true) String publicUrl,
+            @RelativePath ("..") @QueryParameter(value = "protocol") String protocolParameter) {
         Protocol protocol = Protocol.valueOf(protocolParameter);
+        return checkUrl(publicUrl, UrlType.PUBLIC, protocol);
+    }
+    
+    public FormValidation doCheckSecretUrl(
+            @QueryParameter(value = "secretUrl", fixEmpty = true) String publicUrl,
+            @RelativePath ("..") @QueryParameter(value = "protocol") String protocolParameter) {
+        Protocol protocol = Protocol.valueOf(protocolParameter);
+        return checkUrl(publicUrl, UrlType.SECRET, protocol);
+    }
+    
+    private FormValidation checkUrl(String urlOrId, UrlType urlType, Protocol protocol) {
+        String actualUrl = urlOrId;
+        if (urlType == UrlType.SECRET && !StringUtils.isEmpty(actualUrl)) {
+            // Get the credentials
+            actualUrl = Utils.getSecretUrl(urlOrId);
+            if (actualUrl == null) {
+                return FormValidation.error("Could not find secret text credentials with id " + urlOrId);
+            }
+        }
+        
         try {
-            protocol.validateUrl(url);
+            protocol.validateUrl(actualUrl);
             return FormValidation.ok();
         } catch (Exception e) {
-            return FormValidation.error(e.getMessage());
+            String message = e.getMessage();
+            if (urlType == UrlType.SECRET && !StringUtils.isEmpty(actualUrl)) {
+                message = message.replace(actualUrl, "******");
+            }
+            return FormValidation.error(message);
         }
+    }
+    
+    public ListBoxModel doFillSecretUrlItems(@AncestorInPath Item owner, @QueryParameter String secretUrl) {
+        if (owner == null || !owner.hasPermission(Permission.CONFIGURE)) {
+            return new StandardListBoxModel();
+        }
+        
+        // when configuring the job, you only want those credentials that are available to ACL.SYSTEM selectable
+        // as we cannot select from a user's credentials unless they are the only user submitting the build
+        // (which we cannot assume) thus ACL.SYSTEM is correct here.
+        AbstractIdCredentialsListBoxModel<StandardListBoxModel, StandardCredentials> model = new StandardListBoxModel()
+                .withEmptySelection()
+                .withAll(
+                    CredentialsProvider.lookupCredentials(
+                        StringCredentials.class, owner, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()));
+        if (!StringUtils.isEmpty(secretUrl)) {
+            // Select current value, add if missing
+            for (ListBoxModel.Option option : model) {
+                if (option.value.equals(secretUrl)) {
+                    option.selected = true;
+                    break;
+                }
+            }
+        }
+        
+        return model;
     }
 
     @Override

--- a/src/main/java/com/tikal/hudson/plugins/notification/UrlInfo.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/UrlInfo.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 mmitche.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tikal.hudson.plugins.notification;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ *
+ * @author mmitche
+ */
+public class UrlInfo {
+    
+    private String urlOrId;
+    private UrlType urlType;
+    
+    @DataBoundConstructor
+    public UrlInfo(UrlType urlType, String urlOrId) {
+        setUrlOrId ( urlOrId );
+        setUrlType ( urlType );
+    }
+
+    public String getUrlOrId() {
+        return urlOrId;
+    }
+
+    public void setUrlOrId(String urlOrId) {
+        this.urlOrId = urlOrId;
+    }
+
+    public UrlType getUrlType() {
+        return urlType;
+    }
+
+    public void setUrlType(UrlType urlType) {
+        this.urlType = urlType;
+    }
+}

--- a/src/main/java/com/tikal/hudson/plugins/notification/UrlType.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/UrlType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 mmitche.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tikal.hudson.plugins.notification;
+
+/**
+ *
+ * @author mmitche
+ */
+public enum UrlType {
+    SECRET,
+    PUBLIC
+}

--- a/src/main/java/com/tikal/hudson/plugins/notification/Utils.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Utils.java
@@ -1,6 +1,15 @@
 package com.tikal.hudson.plugins.notification;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.security.ACL;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
 import java.util.Arrays;
+import java.util.Collections;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 
 /**
@@ -50,5 +59,27 @@ public final class Utils
         }
 
         return strings[ 0 ];
+    }
+    
+    /**
+     * Get the actual URL from the credential id
+     * @param credentialId Credential id to lookup
+     * @return Actual URL
+     */
+    public static String getSecretUrl(String credentialId) {
+        // Grab the secret text
+        StringCredentials creds = CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(
+            StringCredentials.class, Jenkins.getInstance(), ACL.SYSTEM,
+                Collections.<DomainRequirement>emptyList()),
+            CredentialsMatchers.withId(credentialId));
+        if (creds == null) {
+            return null;
+        }
+        Secret secretUrl = creds.getSecret();
+        if (secretUrl != null) {
+            return secretUrl.getPlainText();
+        }
+        
+        return "";
     }
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/Utils.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Utils.java
@@ -21,9 +21,10 @@ public final class Utils
     {
     }
 
-
     /**
      * Determines if any of Strings specified is either null or empty.
+     * @param strings - Strings to check for empty (whitespace is trimmed) or null.
+     * @return True if any string is empty
      */
     @SuppressWarnings( "MethodWithMultipleReturnPoints" )
     public static boolean isEmpty( String ... strings )
@@ -46,19 +47,17 @@ public final class Utils
 
     /**
      * Verifies neither of Strings specified is null or empty.
-     * @return first String provided
-     * @throws java.lang.IllegalArgumentException
+     * @param strings Strings to check for empty (whitespace is trimmed) or null.
+     * @throws java.lang.IllegalArgumentException Throws this exception if any string is empty.
      */
     @SuppressWarnings( "ReturnOfNull" )
-    public static String verifyNotEmpty( String ... strings )
+    public static void verifyNotEmpty( String ... strings )
     {
         if ( isEmpty( strings ))
         {
             throw new IllegalArgumentException( String.format(
                 "Some String arguments are null or empty: %s", Arrays.toString( strings )));
         }
-
-        return strings[ 0 ];
     }
     
     /**

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -151,6 +151,8 @@ public class BuildState {
 
     /**
      * Updates artifacts Map with S3 links, if corresponding publisher is available.
+     * @param job Job to update
+     * @param run Run to update
      */
     public void updateArtifacts ( Job job, Run run )
     {

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
     <f:section title="Job Notifications">
         <f:entry title="Notification Endpoints" field="endpoints">
@@ -44,16 +44,31 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <f:entry title="URL" description="Where to send messages" field="url">
-                                        <f:textbox name="url" value="${endpoint.url}" />
+                                    <f:dropdownList name="urlInfo" field="urlInfo" title="URL Source">
+                                        <f:dropdownListBlock name="urlInfo" title="Plain Text" selected="${endpoint.getUrlInfo().getUrlType() == 'PUBLIC'}">
+                                            <f:entry title="URL" description="Where to send messages" field="publicUrl">
+                                                <f:textbox name="publicUrl" value="${endpoint.getUrlInfo().getUrlOrId()}" />
+                                            </f:entry>
+                                        </f:dropdownListBlock>
+                                        <f:dropdownListBlock name="urlInfo" title="Credentials Store" selected="${endpoint.getUrlInfo().getUrlType() == 'SECRET'}">
+                                            <f:entry title="URL" description="Where to send messages" field="secretUrl">
+                                                <c:select expressionAllowed="false" value="${endpoint.getUrlInfo().getUrlOrId()}"/>
+                                            </f:entry>
+                                        </f:dropdownListBlock>
+                                    </f:dropdownList>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <f:entry title="Timeout" description="Timeout (in ms)" field="timeout">
+                                        <f:textbox name="timeout" value="${endpoint.timeout}" default="${descriptor.defaultTimeout}"/>
                                     </f:entry>
                                 </td>
                             </tr>
                             <tr>
                                 <td>
-                                    <f:entry title="Timeout" description="Timeout (in ms)"
-                                        field="timeout">
-                                        <f:textbox name="timeout" value="${endpoint.timeout}" default="${descriptor.defaultTimeout}"/>
+                                    <f:entry title="Retries" description="Retries" field="retries">
+                                        <f:textbox name="retries" value="${endpoint.retries}" default="${descriptor.defaultRetries}"/>
                                     </f:entry>
                                 </td>
                             </tr>

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-endpoints.html
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-endpoints.html
@@ -1,2 +1,2 @@
 <div>Sends notifications about Job status to the defined endpoints
-using UDP,TCP or HTTP protocols.</div>
+using UDP, TCP or HTTP protocols.</div>

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-retries.html
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-retries.html
@@ -1,0 +1,1 @@
+<div>Number of retries to before abandoning attempt to contact the endpoint.</div>


### PR DESCRIPTION
Makes the property apply to Job so that Pipeline jobs can use this to wrap execution of the entire pipeline
Adds the option for retries when contacting the endpoint
Adds the option for URLs to be sourced from the credentials store.  This allows for URLs to be referenced by ID in job DSL, avoiding exposure to the public if it was a URL with a sensitive query string, for instance.