### PR TITLE
Make plugin variable friendly

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -62,7 +62,8 @@ public enum Phase {
                                 throw new UnsupportedOperationException("Unknown URL type");
                         }
                         //If Jenkins variable was used for URL, and it was unresolvable, ignore and return.
-                        if (Utils.isEmpty(expandedUrl) || expandedUrl.contains("$")) {
+                        if (expandedUrl.contains("$")) {
+                            listener.getLogger().println( String.format( "Ignoring sending notification due to unresolved variable: %s", urlIdString));
                             return;
                         }
 

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -61,6 +61,11 @@ public enum Phase {
                             default:
                                 throw new UnsupportedOperationException("Unknown URL type");
                         }
+                        //If Jenkins variable was used for URL, and it was unresolvable, ignore and return.
+                        if (Utils.isEmpty(expandedUrl) || expandedUrl.contains("$")) {
+                            return;
+                        }
+
                         listener.getLogger().println( String.format( "Notifying endpoint with %s", urlIdString));
                         JobState jobState = buildJobState(run.getParent(), run, listener, timestamp, target);
                         target.getProtocol().send(expandedUrl,

--- a/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
@@ -115,7 +115,7 @@ public enum Protocol {
 
         @Override
         public void validateUrl( String url ) {
-            //do not validate if Jenkins Variable use used.
+            //do not validate if Jenkins Variable is used.
             if (!url.contains("$")) {
                 try {
                     // noinspection ResultOfObjectAllocationIgnored

--- a/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Protocol.java
@@ -115,12 +115,14 @@ public enum Protocol {
 
         @Override
         public void validateUrl( String url ) {
-            try {
-                // noinspection ResultOfObjectAllocationIgnored
-                new URL( url );
-            } catch ( MalformedURLException e ) {
-                throw new RuntimeException( String.format( "%sUse http://hostname:port/path for endpoint URL",
-                                                           isEmpty ( url ) ? "" : "Invalid URL '" + url + "'. " ));
+            //do not validate if Jenkins Variable use used.
+            if (!url.contains("$")) {
+                try {
+                    // noinspection ResultOfObjectAllocationIgnored
+                    new URL(url);
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(String.format("%sUse http://hostname:port/path for endpoint URL", isEmpty(url) ? "" : "Invalid URL '" + url + "'. "));
+                }
             }
         }
     };


### PR DESCRIPTION
We use the Jenkins Notification Plugin and there are some changes that I need, in order to use it.  
 **1) Remove validation in UI, when a Jenkins variable is referenced. 
 2) If the jenkins variable does not exists or is blank, then do not error out, rather, just do not attempt to send notification.**

My use case is this. We have some common jobs that a bunch of other teams tie into that take care of some common deploy features. I'd like to have these common jobs send notifications to our chat rooms, when they fail, however, everyone has their own chat room. So I plan on passing in the URL as a param or property file that will be loaded into the EnvVars.  When present and populated, the notification plug will send out the notifications. When not, it will just be ignored. I have tried to resolve this issue by wrapping in an conditional build step, that is not possible, as well as the other things I have tried. 

