### PR TITLE
Added a few additional attributes to request body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>token-macro</artifactId>
+            <version>2.3</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
             <version>6.1.26</version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.20</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
             <version>6.1.26</version>

--- a/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Endpoint.java
@@ -41,6 +41,8 @@ public class Endpoint {
     private Integer timeout = DEFAULT_TIMEOUT;
 
     private Integer loglines = 0;
+
+    private String buildNotes;
     
     private Integer retries = DEFAULT_RETRIES;
 
@@ -150,6 +152,19 @@ public class Endpoint {
     @DataBoundSetter
     public void setLoglines(Integer loglines) {
         this.loglines = loglines;
+    }
+
+    public String getBuildNotes() {
+        return buildNotes;
+    }
+
+    /**
+     * Set any additional build information to be sent in message.
+     * @param buildNotes - the additional data
+     */
+    @DataBoundSetter
+    public void setBuildNotes(String buildNotes) {
+        this.buildNotes = buildNotes;
     }
 
     public boolean isJson() {

--- a/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/HudsonNotificationPropertyDescriptor.java
@@ -19,10 +19,10 @@ import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import hudson.Extension;
+import hudson.RelativePath;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.JobPropertyDescriptor;
-import hudson.RelativePath;
 import hudson.security.ACL;
 import hudson.security.Permission;
 import hudson.util.FormValidation;
@@ -30,15 +30,15 @@ import hudson.util.ListBoxModel;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.kohsuke.stapler.AncestorInPath;
 
 @Extension
 public final class HudsonNotificationPropertyDescriptor extends JobPropertyDescriptor {
@@ -121,6 +121,7 @@ public final class HudsonNotificationPropertyDescriptor extends JobPropertyDescr
         endpoint.setTimeout(endpointObjectData.getInt("timeout"));
         endpoint.setRetries(endpointObjectData.getInt("retries"));
         endpoint.setLoglines(endpointObjectData.getInt("loglines"));
+        endpoint.setBuildNotes(endpointObjectData.getString("notes"));
         return endpoint;
     }
     

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -26,6 +26,7 @@ import hudson.model.ParametersAction;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.User;
 import hudson.scm.ChangeLogSet;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
@@ -36,6 +37,7 @@ import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -175,6 +177,7 @@ public enum Phase {
         }
 
         scmState.setChanges(getChangedFiles(run));
+        scmState.setCulprits(getCulprits(run));
 
         return jobState;
     }
@@ -244,6 +247,20 @@ public enum Phase {
         }
 
         return affectedPaths;
+    }
+
+    private List<String> getCulprits(Run run) {
+        List<String> culprits = new ArrayList<>();
+
+        if(run instanceof AbstractBuild) {
+            AbstractBuild build = (AbstractBuild) run;
+            Set<User> buildCulprits = build.getCulprits();
+            for(User user : buildCulprits) {
+                culprits.add(user.getId());
+            }
+        }
+
+        return culprits;
     }
 
     private StringBuilder getLog(Run run, Endpoint target) {

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -110,7 +110,9 @@ public enum Phase {
             status = result.toString();
         }
         
-        boolean buildFailed = event.equals("failed") && this.toString().toLowerCase().equals("finalized") && status.toLowerCase().equals("failure");
+        boolean buildFailed = event.equals("failed") &&
+                this.toString().toLowerCase().equals("finalized") &&
+                (result == Result.UNSTABLE || result == Result.FAILURE);
         		
         return (( event == null ) || event.equals( "all" ) || event.equals( this.toString().toLowerCase()) || buildFailed);
     }

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -26,6 +26,7 @@ import hudson.model.ParametersAction;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.scm.ChangeLogSet;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 import jenkins.model.Jenkins;
@@ -173,6 +174,8 @@ public enum Phase {
             scmState.setCommit( environment.get( "GIT_COMMIT" ));
         }
 
+        scmState.setChanges(getChangedFiles(run));
+
         return jobState;
     }
 
@@ -221,6 +224,26 @@ public enum Phase {
         }
 
         return failedTests;
+    }
+
+    private List<String> getChangedFiles(Run run) {
+        List<String> affectedPaths = new ArrayList<>();
+
+        if(run instanceof AbstractBuild) {
+            AbstractBuild build = (AbstractBuild) run;
+
+            Object[] items = build.getChangeSet().getItems();
+
+            if(items != null && items.length > 0) {
+                for(Object o : items) {
+                    if(o instanceof ChangeLogSet.Entry) {
+                        affectedPaths.addAll(((ChangeLogSet.Entry) o).getAffectedPaths());
+                    }
+                }
+            }
+        }
+
+        return affectedPaths;
     }
 
     private StringBuilder getLog(Run run, Endpoint target) {

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -57,6 +57,8 @@ public class BuildState {
     private TestState testSummary;
 
 
+
+
     /**
      *  Map of artifacts: file name => Map of artifact locations ( location name => artifact URL )
      *  ---

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -24,7 +24,6 @@ import hudson.util.DescribableList;
 import jenkins.model.Jenkins;
 
 import java.io.File;
-import java.lang.StringBuilder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +51,9 @@ public class BuildState {
     private Map<String, String> parameters;
 
     private StringBuilder log;
+
+    private String notes;
+
 
     /**
      *  Map of artifacts: file name => Map of artifact locations ( location name => artifact URL )
@@ -157,6 +159,14 @@ public class BuildState {
 
     public void setLog(StringBuilder log) {
         this.log = log;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String buildNotes) {
+        this.notes = buildNotes;
     }
 
     /**

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -54,6 +54,8 @@ public class BuildState {
 
     private String notes;
 
+    private TestState testSummary;
+
 
     /**
      *  Map of artifacts: file name => Map of artifact locations ( location name => artifact URL )
@@ -167,6 +169,14 @@ public class BuildState {
 
     public void setNotes(String buildNotes) {
         this.notes = buildNotes;
+    }
+
+    public TestState getTestSummary() {
+        return testSummary;
+    }
+
+    public void setTestSummary(TestState testSummary) {
+        this.testSummary = testSummary;
     }
 
     /**

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/ScmState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/ScmState.java
@@ -14,6 +14,8 @@
 package com.tikal.hudson.plugins.notification.model;
 
 
+import java.util.List;
+
 public class ScmState
 {
     private String url;
@@ -21,6 +23,8 @@ public class ScmState
     private String branch;
 
     private String commit;
+
+    private List<String> changes;
 
     public String getUrl ()
     {
@@ -50,5 +54,13 @@ public class ScmState
     public void setCommit ( String commit )
     {
         this.commit = commit;
+    }
+
+    public List<String> getChanges() {
+        return changes;
+    }
+
+    public void setChanges(List<String> changes) {
+        this.changes = changes;
     }
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/ScmState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/ScmState.java
@@ -26,6 +26,8 @@ public class ScmState
 
     private List<String> changes;
 
+    private List<String> culprits;
+
     public String getUrl ()
     {
         return url;
@@ -62,5 +64,13 @@ public class ScmState
 
     public void setChanges(List<String> changes) {
         this.changes = changes;
+    }
+
+    public List<String> getCulprits() {
+        return culprits;
+    }
+
+    public void setCulprits(List<String> culprits) {
+        this.culprits = culprits;
     }
 }

--- a/src/main/java/com/tikal/hudson/plugins/notification/model/TestState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/TestState.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tikal.hudson.plugins.notification.model;
+
+
+import java.util.List;
+
+public class TestState
+{
+    private int total;
+    private int failed;
+    private int passed;
+    private int skipped;
+    private List<String> failedTests;
+
+    public int getTotal() {
+        return total;
+    }
+
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    public int getFailed() {
+        return failed;
+    }
+
+    public void setFailed(int failed) {
+        this.failed = failed;
+    }
+
+    public int getPassed() {
+        return passed;
+    }
+
+    public void setPassed(int passed) {
+        this.passed = passed;
+    }
+
+    public int getSkipped() {
+        return skipped;
+    }
+
+    public void setSkipped(int skipped) {
+        this.skipped = skipped;
+    }
+
+    public List<String> getFailedTests() {
+        return failedTests;
+    }
+
+    public void setFailedTests(List<String> failedTests) {
+        this.failedTests = failedTests;
+    }
+}

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
@@ -86,7 +86,7 @@
                                 <td>
                                     <f:entry title="Notes" description="Additional detail about the build to include in message."
                                         field="notes">
-                                        <f:textbox name="notes" value="${endpoint.notes}" default="" />
+                                        <f:textbox name="notes" value="${endpoint.buildNotes}" default="" />
                                     </f:entry>
                                 </td>
                             </tr>

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
@@ -82,6 +82,15 @@
                                     </f:entry>
                                 </td>
                             </tr>
+                            <tr>
+                                <td>
+                                    <f:entry title="Notes" description="Additional detail about the build to include in message."
+                                        field="notes">
+                                        <f:textbox name="notes" value="${endpoint.notes}" default="" />
+                                    </f:entry>
+                                </td>
+                            </tr>
+
                         </table>
                     </f:entry>
                     <f:repeatableDeleteButton value="${%Delete}" />

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-notes.html
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/help-notes.html
@@ -1,0 +1,6 @@
+<div align="left">
+    <p>Provides a place to include additional build information in the message.
+        This can contain tokens as defined by the
+        <a href="https://wiki.jenkins.io/display/JENKINS/Token+Macro+Plugin">token-macro plugin</a>.
+    </p>
+</div>


### PR DESCRIPTION
To help with how we use this plugin we needed to add a couple of attributes to the request body that gets sent.  These new items include:  
-  A notes field that allows expansion of token-macros -- allows for more arbitrary data
-  scm changes
-  culprits
-  test result summary

Sending a pull request in case you would like these changes too.  Any feedback is welcomed.

Thanks!
