### PR TITLE
Added capability to report on first success after a failure

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -109,11 +109,6 @@ public enum Phase {
         switch(event){
         case "all":
         	return true;
-        case "queued":
-        case "started":
-        case "completed":
-        case "finalized":
-        	return event.equals(this.toString().toLowerCase());
         case "failed":
         	if (result == null) {return false;}
         	return this.equals(FINALIZED) && result.equals(Result.FAILURE);
@@ -122,9 +117,9 @@ public enum Phase {
         	if (result.equals(Result.FAILURE)) {return true;}
         	if (previousRunResult != null && result.equals(Result.SUCCESS) && previousRunResult.equals(Result.FAILURE)) {return true;}
         	return false;
+        default:
+        	return event.equals(this.toString().toLowerCase());	
         }
-        
-        return false;
     }
 
     private JobState buildJobState(Job job, Run run, TaskListener listener, long timestamp, Endpoint target)

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -109,7 +109,9 @@ public enum Phase {
         }
         
 		boolean firstSuccessAfterFailureNotification = event.equals("failedAndFirstSuccess")
-				&& this.toString().toLowerCase().equals("finalized") && result.equals(Result.SUCCESS)
+				&& this.toString().toLowerCase().equals("finalized") && result != null 
+				&& result.equals(Result.SUCCESS)
+				&& previousRunResult != null
 				&& previousRunResult.equals(Result.FAILURE);
 
         boolean buildFailed = (event.equals("failed") || event.equals("failedAndFirstSuccess")) && this.toString().toLowerCase().equals("finalized") && status.toLowerCase().equals("failure");

--- a/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
+++ b/src/main/resources/com/tikal/hudson/plugins/notification/HudsonNotificationProperty/config.jelly
@@ -40,6 +40,7 @@
                                             <f:option value="completed" selected="${endpoint.event == 'completed'}">Job Completed</f:option>
                                             <f:option value="finalized" selected="${endpoint.event == 'finalized'}">Job Finalized</f:option>
                                             <f:option value="failed"	selected="${endpoint.event == 'failed'}">Job Failed</f:option>
+                                            <f:option value="failedAndFirstSuccess"	selected="${endpoint.event == 'failedAndFirstSuccess'}">Job Failed and First Success</f:option>
                                         </select>
                                     </f:entry>
                                 </td>

--- a/src/test/java/com/tikal/hudson/plugins/notification/PhaseTest.java
+++ b/src/test/java/com/tikal/hudson/plugins/notification/PhaseTest.java
@@ -1,0 +1,101 @@
+package com.tikal.hudson.plugins.notification;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import hudson.model.Result;
+
+public class PhaseTest {
+
+	@Test
+	public void testIsRun() {
+		try {
+			Endpoint endPoint = new Endpoint(null);
+			Method isRunMethod = Phase.class.getDeclaredMethod("isRun", Endpoint.class, Result.class, Result.class);
+			isRunMethod.setAccessible(true);
+
+			assertEquals("returns true for null endpoint event",
+					isRunMethod.invoke(Phase.QUEUED, endPoint, null, null), Boolean.TRUE);
+			
+			endPoint.setEvent("all");
+			for (Phase phaseValue : Phase.values()) {
+				assertEquals("all Event returns true for Phase " + phaseValue.toString(),
+						isRunMethod.invoke(phaseValue, endPoint, null, null), Boolean.TRUE);
+			}
+
+			endPoint.setEvent("queued");
+			assertEquals("queued Event returns true for Phase Queued",
+					isRunMethod.invoke(Phase.QUEUED, endPoint, null, null), Boolean.TRUE);
+			assertEquals("queued Event returns false for Phase Started",
+					isRunMethod.invoke(Phase.STARTED, endPoint, null, null), Boolean.FALSE);
+			
+			endPoint.setEvent("started");
+			assertEquals("started Event returns true for Phase Started",
+					isRunMethod.invoke(Phase.STARTED, endPoint, null, null), Boolean.TRUE);
+			assertEquals("started Event returns false for Phase Completed",
+					isRunMethod.invoke(Phase.COMPLETED, endPoint, null, null), Boolean.FALSE);
+
+			
+			endPoint.setEvent("completed");
+			assertEquals("completed Event returns true for Phase Completed",
+					isRunMethod.invoke(Phase.COMPLETED, endPoint, null, null), Boolean.TRUE);
+			assertEquals("completed Event returns false for Phase Finalized",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, null, null), Boolean.FALSE);
+
+			
+			endPoint.setEvent("finalized");
+			assertEquals("finalized Event returns true for Phase Finalized",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, null, null), Boolean.TRUE);
+			assertEquals("finalized Event returns true for Phase Queued",
+					isRunMethod.invoke(Phase.QUEUED, endPoint, null, null), Boolean.FALSE);
+
+			
+			endPoint.setEvent("failed");
+			assertEquals("failed Event returns false for Phase Finalized and no status",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, null, null), Boolean.FALSE);
+			assertEquals("failed Event returns false for Phase Finalized and success status",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, Result.SUCCESS, null), Boolean.FALSE);
+			assertEquals("failed Event returns true for Phase Finalized and success failure",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, Result.FAILURE, null), Boolean.TRUE);
+			assertEquals("failed Event returns false for Phase not Finalized and success failure",
+					isRunMethod.invoke(Phase.COMPLETED, endPoint, Result.FAILURE, null), Boolean.FALSE);
+
+			endPoint.setEvent("failedAndFirstSuccess");
+			assertEquals("failedAndFirstSuccess Event returns false for Phase Finalized and no status",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, null, null), Boolean.FALSE);
+			assertEquals("failedAndFirstSuccess Event returns false for Phase Finalized and no previous status",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, Result.SUCCESS, null), Boolean.FALSE);
+			assertEquals("failedAndFirstSuccess Event returns true for Phase Finalized and no previous status and failed status",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, Result.FAILURE, null), Boolean.TRUE);
+			assertEquals("failedAndFirstSuccess Event returns true for Phase Finalized and failed status",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, Result.FAILURE, Result.FAILURE), Boolean.TRUE);
+			assertEquals("failedAndFirstSuccess Event returns true for Phase Finalized and success status with previous status of failure",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, Result.SUCCESS, Result.FAILURE), Boolean.TRUE);
+			assertEquals("failedAndFirstSuccess Event returns false for Phase Finalized and success status with previous status of success",
+					isRunMethod.invoke(Phase.FINALIZED, endPoint, Result.SUCCESS, Result.SUCCESS), Boolean.FALSE);
+			assertEquals("failedAndFirstSuccess Event returns false for Phase not Finalized",
+					isRunMethod.invoke(Phase.COMPLETED, endPoint, Result.SUCCESS, Result.FAILURE), Boolean.FALSE);
+
+			
+			
+
+		} catch (NoSuchMethodException | SecurityException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IllegalArgumentException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (InvocationTargetException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
We currently use this plugin to get notifications for our CI builds into a chat room.  It is very important to get all the failures, but equally important to know when the build is back to success.  With multiple CI builds happening at the same time, getting notification for every single success starts having people ignore the notifications. I want to be notified for each failure, but also for the first success.  Then ignore all subsequent successes.