### PR TITLE
JENKINS-59908: Fix `expandAll` call so it works with a `Run` parameter.

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -243,6 +243,7 @@ public enum Phase {
             // Catching Throwable here because the TokenMacro plugin is optional
             // so will throw a ClassDefNotFoundError if the plugin is not installed or disabled.
             listener.getLogger().println("Failed to evaluate macro '" + text + "'");
+            listener.getLogger().println(e);
         }
 
         return result;

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -19,6 +19,7 @@ import com.tikal.hudson.plugins.notification.model.ScmState;
 import com.tikal.hudson.plugins.notification.model.TestState;
 
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.ParameterValue;
@@ -238,7 +239,10 @@ public enum Phase {
 
         String result = text;
         try {
-            result = TokenMacro.expandAll((AbstractBuild<?, ?>) build, listener, text);
+            FilePath workspace = build.getExecutor().getCurrentWorkspace();
+            if ( workspace != null ) {
+                result = TokenMacro.expandAll(build, workspace, listener, text);
+            }
         } catch (Throwable e) {
             // Catching Throwable here because the TokenMacro plugin is optional
             // so will throw a ClassDefNotFoundError if the plugin is not installed or disabled.


### PR DESCRIPTION
[JENKINS-59908](https://issues.jenkins-ci.org/browse/JENKINS-59908): Fix `expandAll` call so it works with a `Run` parameter.

Previously, due to the blanket catch of a `Throwable` here, the code was masking the fact that `TokenMacro.expandAll` was never invoked, failing like this:

```
Failed to evaluate macro ''
java.lang.ClassCastException: org.jenkinsci.plugins.workflow.job.WorkflowRun cannot be cast to hudson.model.AbstractBuild
```

- Improve logging when a blanket Throwable is swallowed.