### PR TITLE
JENKINS-59908: Fix expandAll call so it works with a Run parameter. 

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -33,13 +33,13 @@ import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
-
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 
@@ -243,7 +243,9 @@ public enum Phase {
 
         String result = text;
         try {
-            FilePath workspace = build.getExecutor().getCurrentWorkspace();
+            FilePath workspace = Optional.ofNullable(build.getExecutor())
+                .orElseThrow(() -> new IllegalStateException("Failed to obtained executor of this run"))
+                .getCurrentWorkspace();
             if ( workspace != null ) {
                 result = TokenMacro.expandAll(build, workspace, listener, text);
             }

--- a/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/Phase.java
@@ -19,6 +19,7 @@ import com.tikal.hudson.plugins.notification.model.ScmState;
 import com.tikal.hudson.plugins.notification.model.TestState;
 
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.ParameterValue;
@@ -242,11 +243,15 @@ public enum Phase {
 
         String result = text;
         try {
-            result = TokenMacro.expandAll((AbstractBuild<?, ?>) build, listener, text);
+            FilePath workspace = build.getExecutor().getCurrentWorkspace();
+            if ( workspace != null ) {
+                result = TokenMacro.expandAll(build, workspace, listener, text);
+            }
         } catch (Throwable e) {
             // Catching Throwable here because the TokenMacro plugin is optional
             // so will throw a ClassDefNotFoundError if the plugin is not installed or disabled.
             listener.getLogger().println("Failed to evaluate macro '" + text + "'");
+            listener.getLogger().println(e);
         }
 
         return result;


### PR DESCRIPTION
Same as #38

JENKINS-59908: Fix `expandAll` call so it works with a Run parameter.

Previously, due to the blanket catch of a Throwable here, the code was masking the fact that TokenMacro.expandAll was never invoked, failing like this:
```
Failed to evaluate macro ''
java.lang.ClassCastException: org.jenkinsci.plugins.workflow.job.WorkflowRun cannot be cast to hudson.model.AbstractBuild
```
Also, Improve logging when a blanket Throwable is swallowed.