### PR TITLE
SCM: Get info from git plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>git</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>credentials</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The "scm" field in the notifications is often empty. I think it only gets populated after the actual build phase. This is useless if the job stops before anything gets built. With this change, the scm information gets pulled directly from the job description, rather than build environment.

Issues this would solve:
- https://issues.jenkins.io/browse/JENKINS-67822
- https://issues.jenkins.io/browse/JENKINS-37424
- https://issues.jenkins.io/browse/JENKINS-21915

I tested it, and it works.