### PR TITLE
Add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/notification-plugin-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+---
 version: 2
 updates:
-# Maintain dependencies for your plugin
-- package-ecosystem: maven
-  directory: /
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
-  target-branch: master
-# Maintain dependencies for GitHub Actions
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
+  # Maintain dependencies for your plugin
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Add `CODEOWNERS` file to match the archetype so that code owners get notifications of new PRs.

Also, reformat the Dependabot YAML file to be `yamllint`-clean, which makes the formatting easier to read and consistent with other YAML files in the Jenkins organization.